### PR TITLE
Optionally implement bytemuck traits for Endians

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "crates-io.md"
 
 [dependencies]
 bytecheck = { version = "~0.6.7", optional = true, default-features = false }
+bytemuck = { version = "^1.4.0", optional = true, features = ["derive"], default-features = false }
 
 [features]
 default = ["std"]

--- a/src/impl_bytemuck.rs
+++ b/src/impl_bytemuck.rs
@@ -1,0 +1,63 @@
+// implementations of bytemuck Zeroable and Pod traits for BigEndian and LittleEndian variants of
+// types which are themselves Zeroable and Pod. This enables use of bytemuck::cast* methods to
+// safely transmute to and from these types.
+
+use bytemuck::{Zeroable, Pod};
+use crate::{Primitive, BigEndian, LittleEndian};
+
+// SAFETY: T and T::Storage is Zeroable and Pod. LittleEndian is repr(transparent)
+// this satisfies the safety contracts of Zeroable and Pod.
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> Zeroable for LittleEndian<T>
+where T: Primitive + Zeroable,
+      T::Storage: Zeroable {}
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> Pod for LittleEndian<T>
+where T: Primitive + Pod + Copy + 'static,
+      T::Storage: Pod {}
+
+
+// SAFETY: T and T::Storage is Zeroable and Pod. BigEndian is repr(transparent)
+// this satisfies the safety contracts of Zeroable and Pod.
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> Zeroable for BigEndian<T>
+where T: Primitive + Zeroable,
+      T::Storage: Zeroable {}
+#[cfg(feature = "bytemuck")]
+unsafe impl<T> Pod for BigEndian<T>
+where T: Primitive + Pod + Copy + 'static,
+      T::Storage: Pod {}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    use bytemuck::Pod;
+
+    #[test]
+    fn check_impl_pod() {
+        fn assert_impl_pod<T: Pod>() {}
+
+        assert_impl_pod::<u16_le>();
+        assert_impl_pod::<u16_be>();
+        assert_impl_pod::<u32_le>();
+        assert_impl_pod::<u32_be>();
+        assert_impl_pod::<u64_le>();
+        assert_impl_pod::<u64_be>();
+
+        assert_impl_pod::<i16_le>();
+        assert_impl_pod::<i16_be>();
+        assert_impl_pod::<i32_le>();
+        assert_impl_pod::<i32_be>();
+        assert_impl_pod::<i64_le>();
+        assert_impl_pod::<i64_be>();
+
+        assert_impl_pod::<f32_le>();
+        assert_impl_pod::<f32_be>();
+        assert_impl_pod::<f64_le>();
+        assert_impl_pod::<f64_be>();
+
+        // char is not Pod, so these types shouldn't be either
+        //assert_impl_pod::<char_be>();
+        //assert_impl_pod::<char_le>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ mod impl_traits;
 #[cfg(feature = "validation")]
 #[macro_use]
 mod impl_validation;
+#[cfg(feature = "bytemuck")]
+mod impl_bytemuck;
 
 #[cfg(feature = "validation")]
 use bytecheck::{CharCheckError, CheckBytes, NonZeroCheckError};
@@ -98,6 +100,7 @@ pub unsafe trait Primitive {
 /// This is mostly useful for `const` conversions to big- and little-endian types in contexts where
 /// type inference is required. Because it's native-endian, the inner value is publicly exposed.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Zeroable, bytemuck::Pod))]
 #[repr(transparent)]
 pub struct NativeEndian<T> {
     /// The value of the type


### PR DESCRIPTION
Hey, I like this project, and I found myself in a situation where I wanted to use [bytemuck](https://docs.rs/bytemuck/1.14.0/bytemuck/) to cast a struct containing some `u16_le`s. Figured other people might find that useful as well so here we are!

This adds impls of `bytemuck::Pod` and `bytemuck::Zeroable` for NativeEndian, BigEndian and LittleEndian, which enables use of `bytemuck::cast*`-methods to safely transmute to and from these types.

Let me know if you're interested in this or not :)