### PR TITLE
Optionally implement `Zeroable` and `Pod` from bytemuck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bytecheck:
+        external:
           - ''
-          - bytecheck
+          - bytecheck bytemuck-1
 
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --verbose --tests --no-default-features --features "${{ matrix.bytecheck }}"
+      - run: cargo test --verbose --tests --no-default-features --features "${{ matrix.external }}"
 
   toolchain:
     name: Toolchain / ${{ matrix.toolchain }} ${{ matrix.opt }}
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo install cross
-      - run: cross build --no-default-features --features "bytecheck" --target ${{ matrix.target }} --verbose
+      - run: cross build --no-default-features --features "bytecheck bytemuck-1" --target ${{ matrix.target }} --verbose
 
   format:
     name: Format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/rend"
 
 [dependencies]
 bytecheck = { version = "0.8", optional = true, default-features = false }
+bytemuck = { version = "1.17.1", optional = true, default-features = false }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/rend"
 
 [dependencies]
 bytecheck = { version = "0.8", optional = true, default-features = false }
-bytemuck = { version = "1.17.1", optional = true, default-features = false }
+bytemuck-1 = { package = "bytemuck", version = "1", optional = true, default-features = false }
 
 [features]
 default = []

--- a/src/common.rs
+++ b/src/common.rs
@@ -179,8 +179,8 @@ macro_rules! impl_float {
         // SAFETY: An impl of `CheckBytes` with a `check_bytes` function that is
         // a no-op is sound for floats.
         unsafe_impl_check_bytes_noop!(for $name);
-        // SAFETY: `Pod` is implemented for `f32` and `f64` - as such, flipped representations
-        // must also be `Pod`.
+        // SAFETY: `Pod` is implemented for `f32` and `f64` - as such, flipped
+        // representations must also be `Pod`.
         unsafe_impl_zeroable!(for $name);
         unsafe_impl_pod!(for $name);
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -243,6 +243,8 @@ macro_rules! impl_char {
         // SAFETY: An all-zero bits `char` is just the null char, whether you
         // read it forwards or backwards.
         unsafe_impl_zeroable!(for $name);
+        // SAFETY: `char`s do not contain any uninit bytes.
+        unsafe_impl_no_uninit!(for $name);
 
         impl_clone_and_copy!(for $name);
         impl_fmt!(Debug for $name);
@@ -345,6 +347,9 @@ macro_rules! impl_nonzero {
                 unsafe { <$prim>::new_unchecked(self.get()) }
             }
         }
+
+        // SAFETY: Non-zero integers do not contain any uninit bytes.
+        unsafe_impl_no_uninit!(for $name);
 
         impl_clone_and_copy!(for $name);
         impl_fmt!(Binary for $name);

--- a/src/common.rs
+++ b/src/common.rs
@@ -29,6 +29,10 @@ macro_rules! impl_signed_integer_traits {
         // SAFETY: An impl of `CheckBytes` with a `check_bytes` function that is
         // a no-op is sound for signed integers.
         unsafe_impl_check_bytes_noop!(for $name);
+        // SAFETY: Signed integers are inhabited and allow all bit patterns,
+        // fulfilling the requirements of `Zeroable` and `Pod`.
+        unsafe_impl_zeroable!(for $name);
+        unsafe_impl_pod!(for $name);
 
         impl_binop!(Add::add for $name: $prim);
         impl_binassign!(AddAssign::add_assign for $name: $prim);
@@ -76,6 +80,10 @@ macro_rules! impl_unsigned_integer_traits {
         // SAFETY: An impl of `CheckBytes` with a `check_bytes` function that is
         // a no-op is sound for unsigned integers.
         unsafe_impl_check_bytes_noop!(for $name);
+        // SAFETY: Unsigned integers are inhabited and allow all bit patterns,
+        // fulfilling the requirements of `Zeroable` and `Pod`.
+        unsafe_impl_zeroable!(for $name);
+        unsafe_impl_pod!(for $name);
 
         impl_binop!(Add::add for $name: $prim);
         impl_binassign!(AddAssign::add_assign for $name: $prim);
@@ -171,6 +179,10 @@ macro_rules! impl_float {
         // SAFETY: An impl of `CheckBytes` with a `check_bytes` function that is
         // a no-op is sound for floats.
         unsafe_impl_check_bytes_noop!(for $name);
+        // SAFETY: `Pod` is implemented for `f32` and `f64` - as such, flipped representations
+        // must also be `Pod`.
+        unsafe_impl_zeroable!(for $name);
+        unsafe_impl_pod!(for $name);
 
         impl_binop!(Add::add for $name: $prim);
         impl_binassign!(AddAssign::add_assign for $name: $prim);
@@ -227,6 +239,10 @@ macro_rules! impl_char {
                 unsafe { transmute::<u32, char>(swap_endian!($endian self.0)) }
             }
         }
+
+        // SAFETY: An all-zero bits `char` is just the null char, whether you
+        // read it forwards or backwards.
+        unsafe_impl_zeroable!(for $name);
 
         impl_clone_and_copy!(for $name);
         impl_fmt!(Debug for $name);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -398,14 +398,15 @@ macro_rules! unsafe_impl_zeroable {
         unsafe impl bytemuck::Zeroable for $name {}
     };
 }
+
 /// # Safety
 ///
 /// Read the safety requirements of [`bytemuck::Pod`].
 /// In general, any type that is natively `Pod` (e.g. `u64`, `AtomicU32`) will
 /// be `Pod` even if wrapped (`u64_le`).
 ///
-/// It is required that `$name` has an impl for `Zeroable` for this macro to work.
-/// See [`unsafe_impl_zeroable!()`].
+/// It is required that `$name` has an impl for `Zeroable` for this macro to
+/// work. See [`unsafe_impl_zeroable!()`].
 macro_rules! unsafe_impl_pod {
     (for $name:ident) => {
         #[cfg(feature = "bytemuck")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -394,8 +394,8 @@ macro_rules! unsafe_impl_check_bytes_noop {
 /// (e.g. `u64`, `i32`) that is `Zeroable` will also be zeroable.
 macro_rules! unsafe_impl_zeroable {
     (for $name:ident) => {
-        #[cfg(feature = "bytemuck")]
-        unsafe impl bytemuck::Zeroable for $name {}
+        #[cfg(feature = "bytemuck-1")]
+        unsafe impl bytemuck_1::Zeroable for $name {}
     };
 }
 
@@ -409,7 +409,19 @@ macro_rules! unsafe_impl_zeroable {
 /// work. See [`unsafe_impl_zeroable!()`].
 macro_rules! unsafe_impl_pod {
     (for $name:ident) => {
-        #[cfg(feature = "bytemuck")]
-        unsafe impl bytemuck::Pod for $name {}
+        #[cfg(feature = "bytemuck-1")]
+        unsafe impl bytemuck_1::Pod for $name {}
+    };
+}
+
+/// # Safety
+///
+/// Read the safety requirements of [`bytemuck::NoUninit`].
+/// All primitive types are `NoUninit` and as a result, all of this crates's
+/// wrapped primitive types are also `NoUninit`.
+macro_rules! unsafe_impl_no_uninit {
+    (for $name:ident) => {
+        #[cfg(feature = "bytemuck-1")]
+        unsafe impl bytemuck_1::NoUninit for $name {}
     };
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -386,3 +386,29 @@ macro_rules! unsafe_impl_check_bytes_noop {
         }
     };
 }
+
+/// # Safety
+///
+/// An all-zero bit pattern for `$name` must be a valid value.
+/// As a rule, any derivative type (e.g. `u64_le` or `i32_be`) of a native type
+/// (e.g. `u64`, `i32`) that is `Zeroable` will also be zeroable.
+macro_rules! unsafe_impl_zeroable {
+    (for $name:ident) => {
+        #[cfg(feature = "bytemuck")]
+        unsafe impl bytemuck::Zeroable for $name {}
+    };
+}
+/// # Safety
+///
+/// Read the safety requirements of [`bytemuck::Pod`].
+/// In general, any type that is natively `Pod` (e.g. `u64`, `AtomicU32`) will
+/// be `Pod` even if wrapped (`u64_le`).
+///
+/// It is required that `$name` has an impl for `Zeroable` for this macro to work.
+/// See [`unsafe_impl_zeroable!()`].
+macro_rules! unsafe_impl_pod {
+    (for $name:ident) => {
+        #[cfg(feature = "bytemuck")]
+        unsafe impl bytemuck::Pod for $name {}
+    };
+}


### PR DESCRIPTION
This PR adds implementations for `Zeroable` and `Pod` to some types in rend where they are applicable.
These traits do not get implemented unless the `bytemuck` feature is enabled.

Specifically, at the time of writing:
- Two trait impl macros have been added to `traits.rs`: `unsafe_impl_zeroable` and `unsafe_impl_pod`.
- `Zeroable` and `Pod` impls have been added for the unsigned integers, signed integers, and floats.
- `Zeroable` has been implemented for `char`.

I refrained from implementing these values for atomics and other variations of the Zeroable/Pod types. Those require more features to be enabled on the bytemuck crate.