### PR TITLE
feat: Implement `serde::Serialize` and `serde::Deserialize` for integers and floats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ documentation = "https://docs.rs/rend"
 
 [dependencies]
 bytecheck = { version = "0.8", optional = true, default-features = false }
+serde = { version = "1.0.210", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = []
+serde = ["dep:serde"]
 
 [patch.crates-io]
 bytecheck = { git = "https://github.com/rkyv/bytecheck" }

--- a/src/common.rs
+++ b/src/common.rs
@@ -68,6 +68,7 @@ macro_rules! impl_signed_integer_traits {
         impl_binassign!(SubAssign::sub_assign for $name: $prim);
         impl_fmt!(UpperExp for $name);
         impl_fmt!(UpperHex for $name);
+        impl_serde!(for $name: $prim);
     };
 }
 
@@ -114,6 +115,7 @@ macro_rules! impl_unsigned_integer_traits {
         impl_binassign!(SubAssign::sub_assign for $name: $prim);
         impl_fmt!(UpperExp for $name);
         impl_fmt!(UpperHex for $name);
+        impl_serde!(for $name: $prim);
     };
 }
 
@@ -192,6 +194,7 @@ macro_rules! impl_float {
         impl_binassign!(RemAssign::rem_assign for $name: $prim);
         impl_binop!(Sub::sub for $name: $prim);
         impl_binassign!(SubAssign::sub_assign for $name: $prim);
+        impl_serde!(for $name: $prim);
         impl_fmt!(UpperExp for $name);
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 //! ## Features
 //!
 //! - `bytecheck`: Enables support for validating types using `bytecheck`.
+//! - `serde`: Derives [`serde::Serialize`] and [`serde::Deserialize`] for types
+//!   that support it.
 //!
 //! ## Example:
 #![doc = include_str!("../example.md")]


### PR DESCRIPTION
As per title: an initial contribution towards a broader implementation of `serde`'s traits. As of now, the implementations are feature gated. 

Let me know if the general structure is good enough, and then we can figure out what's the best way to test the implementations. 